### PR TITLE
[fix] When called in a loop, the output is repeated

### DIFF
--- a/src/lib/compressor.ts
+++ b/src/lib/compressor.ts
@@ -37,6 +37,7 @@ function compress(config?: globals.IConfig) {
       writers = globals.writers,
       output = globals.output,
       dest = globals.config.dest,
+      clear = globals.clear,
       version = globals.config.version,
       license = globals.config.license;
 
@@ -127,7 +128,7 @@ function compress(config?: globals.IConfig) {
             .catch(error => reject(error));
         });
       }
-
+      clear();
       resolve(output.join('\n'));
     });
   });

--- a/src/lib/generateoutput.ts
+++ b/src/lib/generateoutput.ts
@@ -1,7 +1,5 @@
 ﻿import globals = require('./globals');
 
-var output = globals.output;
-
 function removeEmptyStringsFromEnd(output: Array<string>) {
     while (!output[output.length - 1]) {
         output.pop();
@@ -13,8 +11,10 @@ function removeEmptyStringsFromEnd(output: Array<string>) {
  * function, building the output array.
  */
 function generateOutput() {
+    var output = globals.output;
     var writers = globals.writers,
         previousLine = '';
+        
 
     writers.forEach((writer) => {
         previousLine = writer.write(output, previousLine);

--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -32,6 +32,11 @@ export interface IConfig {
    * license will be replaced with the version.
    */
   license?: string;
+
+  /**
+   * Clear global cache var
+   */
+  clear?: Function;
 }
 
 export interface IObject<T> {
@@ -83,6 +88,15 @@ export function initialize(cfg: IConfig) {
   }
 
   return config;
+}
+
+/**
+ * Clear cache
+ */
+export function clear() {
+  writers = [];
+  output = [];
+  imports = {};
 }
 
 export var config: IConfig,


### PR DESCRIPTION
When i use this package like this:
```javascript
const bundle = require('less-bundle-promise');
const styles = ['xxx/xxx.less', 'xxx2/xxx.less'];
(async () => {
  let index = 0;
  for (const p of styles) {
    const css = await bundle({ src: p });
    fs.writeFileSync(path.join(__dirname, 'dist', `${index}.less`), css);
    index++;
  }
})();
```

The output is accumulated in turn，like this:
0.less
```less
@prefix: 'a';
// other
```

1.less
```less
@prefix: 'a';
// other
@prefix: 'a';
// other
```